### PR TITLE
update cache version

### DIFF
--- a/.github/workflows/gh-pages-build.yml
+++ b/.github/workflows/gh-pages-build.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: '12.x'
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: '12.x'
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
to fix error during deploy: 

> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v1. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down